### PR TITLE
Update blueprints

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -4,12 +4,11 @@
 	"steps": [
 		{
 			"step": "login",
-			"username": "admin",
-			"password": "password"
+			"username": "admin"
 		},
 		{
 			"step": "installPlugin",
-			"pluginZipFile": {
+			"pluginData": {
 				"resource": "wordpress.org/plugins",
 				"slug": "flexible-spacer-block"
 			}


### PR DESCRIPTION
Closes #67

動作確認用URL: https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/t-hamano/flexible-spacer-block/refs/heads/update-blueprints/.wordpress-org/blueprints/blueprint.json