### PR TITLE
Wrap device height controls in BaseControl group

### DIFF
--- a/src/edit.tsx
+++ b/src/edit.tsx
@@ -11,6 +11,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { InspectorControls, BlockControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ResizableBox,
+	BaseControl,
 	RangeControl,
 	ToggleControl,
 	HorizontalRule,
@@ -338,41 +339,48 @@ export default function Edit( {
 							onDeselect={ control.onDeselect }
 						>
 							<VStack spacing={ 4 }>
-								<VStack
-									spacing={ 2 }
-									onMouseEnter={ () => setActiveDevice( control.slug ) }
-									onMouseLeave={ () => setActiveDevice( undefined ) }
-								>
-									<Grid align="end" templateColumns="1fr 0.7fr">
-										<RangeControl
-											label={ control.label }
-											beforeIcon={ <Icon icon={ control.icon } /> }
-											min={ MIN_SPACER_HEIGHT }
-											max={ MAX_SPACER_HEIGHT }
-											value={ control.quantity }
-											withInputField={ false }
-											onChange={ control.onChange }
-											__nextHasNoMarginBottom
-											__next40pxDefaultSize
-										/>
-										<UnitControl
-											hideLabelFromVision
-											label={ control.label }
-											value={ control.value }
-											min={ MIN_SPACER_HEIGHT }
-											onChange={ control.onChange }
-											size="__unstable-large"
-										/>
-									</Grid>
-									{ control.onNegativeChange && (
-										<ToggleControl
-											label={ __( 'Negative space', 'flexible-spacer-block' ) }
-											checked={ control.isNegative }
-											onChange={ control.onNegativeChange }
-											__nextHasNoMarginBottom
-										/>
-									) }
-								</VStack>
+								<BaseControl __nextHasNoMarginBottom>
+									<div
+										role="group"
+										aria-labelledby={ `fsb-spacer-${ control.slug }__label` }
+										onMouseEnter={ () => setActiveDevice( control.slug ) }
+										onMouseLeave={ () => setActiveDevice( undefined ) }
+									>
+										<BaseControl.VisualLabel id={ `fsb-spacer-${ control.slug }__label` }>
+											{ control.label }
+										</BaseControl.VisualLabel>
+										<VStack spacing={ 2 }>
+											<Grid align="end" templateColumns="1fr 0.7fr">
+												<RangeControl
+													label={ __( 'Height', 'flexible-spacer-block' ) }
+													hideLabelFromVision
+													beforeIcon={ <Icon icon={ control.icon } /> }
+													min={ MIN_SPACER_HEIGHT }
+													max={ MAX_SPACER_HEIGHT }
+													value={ control.quantity }
+													withInputField={ false }
+													onChange={ control.onChange }
+													__next40pxDefaultSize
+												/>
+												<UnitControl
+													hideLabelFromVision
+													label={ __( 'Height', 'flexible-spacer-block' ) }
+													value={ control.value }
+													min={ MIN_SPACER_HEIGHT }
+													onChange={ control.onChange }
+													size="__unstable-large"
+												/>
+											</Grid>
+											{ control.onNegativeChange && (
+												<ToggleControl
+													label={ __( 'Negative space', 'flexible-spacer-block' ) }
+													checked={ control.isNegative }
+													onChange={ control.onNegativeChange }
+												/>
+											) }
+										</VStack>
+									</div>
+								</BaseControl>
 								<HorizontalRule />
 							</VStack>
 						</ToolsPanelItem>

--- a/test/e2e/block.spec.ts
+++ b/test/e2e/block.spec.ts
@@ -16,7 +16,10 @@ test.describe( 'Block', () => {
 	test( 'should change all height', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'fsb/flexible-spacer' } );
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'spinbutton', { name: 'All heights' } ).fill( '200' );
+		await page
+			.getByRole( 'group', { name: 'All heights' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '200' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -30,9 +33,18 @@ test.describe( 'Block', () => {
 	test( 'should change each height', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'fsb/flexible-spacer' } );
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'spinbutton', { name: 'Desktop height' } ).fill( '200' );
-		await page.getByRole( 'spinbutton', { name: 'Tablet height' } ).fill( '300' );
-		await page.getByRole( 'spinbutton', { name: 'Mobile height' } ).fill( '400' );
+		await page
+			.getByRole( 'group', { name: 'Desktop height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '200' );
+		await page
+			.getByRole( 'group', { name: 'Tablet height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '300' );
+		await page
+			.getByRole( 'group', { name: 'Mobile height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '400' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -48,9 +60,18 @@ test.describe( 'Block', () => {
 	test( 'should apply negative space', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'fsb/flexible-spacer' } );
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'spinbutton', { name: 'Desktop height' } ).fill( '200' );
-		await page.getByRole( 'spinbutton', { name: 'Tablet height' } ).fill( '300' );
-		await page.getByRole( 'spinbutton', { name: 'Mobile height' } ).fill( '400' );
+		await page
+			.getByRole( 'group', { name: 'Desktop height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '200' );
+		await page
+			.getByRole( 'group', { name: 'Tablet height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '300' );
+		await page
+			.getByRole( 'group', { name: 'Mobile height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '400' );
 		await page.getByRole( 'checkbox', { name: 'Negative space' } ).nth( 0 ).check();
 		await page.getByRole( 'checkbox', { name: 'Negative space' } ).nth( 1 ).check();
 		await page.getByRole( 'checkbox', { name: 'Negative space' } ).nth( 2 ).check();
@@ -60,9 +81,18 @@ test.describe( 'Block', () => {
 	test( 'should apply edged value correctly if the value is falsy', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'fsb/flexible-spacer' } );
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'spinbutton', { name: 'Desktop height' } ).fill( '0' );
-		await page.getByRole( 'spinbutton', { name: 'Tablet height' } ).fill( '' );
-		await page.getByRole( 'spinbutton', { name: 'Mobile height' } ).fill( '0' );
+		await page
+			.getByRole( 'group', { name: 'Desktop height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '0' );
+		await page
+			.getByRole( 'group', { name: 'Tablet height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '' );
+		await page
+			.getByRole( 'group', { name: 'Mobile height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '0' );
 		await page.getByRole( 'combobox', { name: 'Select unit' } ).nth( 3 ).selectOption( 'em' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -73,9 +103,18 @@ test.describe( 'Block', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'fsb/flexible-spacer' } );
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'spinbutton', { name: 'Desktop height' } ).fill( '0' );
-		await page.getByRole( 'spinbutton', { name: 'Tablet height' } ).fill( '' );
-		await page.getByRole( 'spinbutton', { name: 'Mobile height' } ).fill( '0' );
+		await page
+			.getByRole( 'group', { name: 'Desktop height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '0' );
+		await page
+			.getByRole( 'group', { name: 'Tablet height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '' );
+		await page
+			.getByRole( 'group', { name: 'Mobile height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '0' );
 		await page.getByRole( 'checkbox', { name: 'Negative space' } ).nth( 0 ).check();
 		await page.getByRole( 'checkbox', { name: 'Negative space' } ).nth( 1 ).check();
 		await page.getByRole( 'checkbox', { name: 'Negative space' } ).nth( 2 ).check();
@@ -95,7 +134,10 @@ test.describe( 'Block', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'fsb/flexible-spacer' } );
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'spinbutton', { name: 'Desktop height' } ).fill( '200' );
+		await page
+			.getByRole( 'group', { name: 'Desktop height' } )
+			.getByRole( 'spinbutton', { name: 'Height' } )
+			.fill( '200' );
 		await page.getByRole( 'combobox', { name: 'Select unit' } ).nth( 1 ).selectOption( 'em' );
 		await page.getByRole( 'checkbox', { name: 'Negative space' } ).nth( 0 ).check();
 		await editor.transformBlockTo( 'core/spacer' );


### PR DESCRIPTION
Group each device's RangeControl, UnitControl and negative-space toggle under a single BaseControl.VisualLabel and a role="group" container tied to that label via aria-labelledby. This gives screen readers the device context for the whole group while letting each control carry a generic "Height" label instead of repeating the device name.