### PR TITLE
Keep style attribute when transforming spacer blocks

### DIFF
--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -15,13 +15,22 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/spacer' ],
-			transform: ( { anchor, height }: { anchor?: string; height?: string } ) => {
+			transform: ( {
+				anchor,
+				height,
+				style,
+			}: {
+				anchor?: string;
+				height?: string;
+				style?: Record< string, unknown >;
+			} ) => {
 				const [ parsedQuantity = DEFAULT_SPACER_HEIGHT, parsedUnit = DEFAULT_SPACER_HEIGHT_UNIT ] =
 					parseQuantityAndUnitFromRawValue( height );
 				const newHeight = `${ parsedQuantity }${ parsedUnit }`;
 
 				return createBlock( metadata.name, {
 					anchor,
+					style,
 					heightLg: newHeight,
 					heightMd: newHeight,
 					heightSm: newHeight,
@@ -33,12 +42,21 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/spacer' ],
-			transform: ( { anchor, heightLg }: { anchor?: string; heightLg?: string } ) => {
+			transform: ( {
+				anchor,
+				heightLg,
+				style,
+			}: {
+				anchor?: string;
+				heightLg?: string;
+				style?: Record< string, unknown >;
+			} ) => {
 				const [ parsedQuantity = DEFAULT_SPACER_HEIGHT, parsedUnit = DEFAULT_SPACER_HEIGHT_UNIT ] =
 					parseQuantityAndUnitFromRawValue( heightLg );
 				const newHeight = `${ parsedQuantity }${ parsedUnit }`;
 				return createBlock( 'core/spacer', {
 					anchor,
+					style,
 					height: newHeight,
 				} );
 			},

--- a/test/e2e/__snapshots__/Block-should-be-converted-to-core-spacer-block-by-keeping-metadata-and-CSS-1-chromium.txt
+++ b/test/e2e/__snapshots__/Block-should-be-converted-to-core-spacer-block-by-keeping-metadata-and-CSS-1-chromium.txt
@@ -1,0 +1,3 @@
+<!-- wp:spacer {"metadata":{"name":"My Spacer","blockVisibility":{"viewport":{"mobile":false}}},"style":{"css":"background: red;"}} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer has-custom-css"></div>
+<!-- /wp:spacer -->

--- a/test/e2e/__snapshots__/Block-should-be-converted-to-flexible-spacer-block-by-keeping-metadata-and-CSS-1-chromium.txt
+++ b/test/e2e/__snapshots__/Block-should-be-converted-to-flexible-spacer-block-by-keeping-metadata-and-CSS-1-chromium.txt
@@ -1,0 +1,3 @@
+<!-- wp:fsb/flexible-spacer {"metadata":{"name":"My Spacer","blockVisibility":{"viewport":{"mobile":false}}},"style":{"css":"background: red;"}} -->
+<div aria-hidden="true" class="wp-block-fsb-flexible-spacer fsb-flexible-spacer has-custom-css"><div class="fsb-flexible-spacer__device fsb-flexible-spacer__device--lg" style="height:100px"></div><div class="fsb-flexible-spacer__device fsb-flexible-spacer__device--md" style="height:100px"></div><div class="fsb-flexible-spacer__device fsb-flexible-spacer__device--sm" style="height:100px"></div></div>
+<!-- /wp:fsb/flexible-spacer -->

--- a/test/e2e/block.spec.ts
+++ b/test/e2e/block.spec.ts
@@ -144,6 +144,23 @@ test.describe( 'Block', () => {
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	test( 'should be converted to core spacer block by keeping metadata and CSS', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'fsb/flexible-spacer',
+			attributes: {
+				metadata: {
+					name: 'My Spacer',
+					blockVisibility: { viewport: { mobile: false } },
+				},
+				style: { css: 'background: red;' },
+			},
+		} );
+		await editor.transformBlockTo( 'core/spacer' );
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	test( 'should be converted to flexible spacer block', async ( { editor } ) => {
 		await editor.insertBlock( { name: 'core/spacer' } );
 		await editor.transformBlockTo( 'fsb/flexible-spacer' );
@@ -157,6 +174,23 @@ test.describe( 'Block', () => {
 		await editor.insertBlock( { name: 'core/spacer' } );
 		await editor.openDocumentSettingsSidebar();
 		await page.fill( '.block-editor-block-inspector input[type="number"]', '200' );
+		await editor.transformBlockTo( 'fsb/flexible-spacer' );
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	test( 'should be converted to flexible spacer block by keeping metadata and CSS', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/spacer',
+			attributes: {
+				metadata: {
+					name: 'My Spacer',
+					blockVisibility: { viewport: { mobile: false } },
+				},
+				style: { css: 'background: red;' },
+			},
+		} );
 		await editor.transformBlockTo( 'fsb/flexible-spacer' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
Block transforms only passed anchor and height to the new block, so the style attribute (including custom CSS in style.css) was dropped on conversion. Unlike className and metadata, no core filter retains style across switchToBlockType, so it must be passed explicitly in the transform function. Carry style through both directions and add e2e snapshot tests covering metadata and custom CSS retention.

Fixes #108